### PR TITLE
change judgement of duplicate textures

### DIFF
--- a/app/Http/Controllers/SkinlibController.php
+++ b/app/Http/Controllers/SkinlibController.php
@@ -252,7 +252,7 @@ class SkinlibController extends Controller
             foreach ($results as $result) {
                 // if the texture already uploaded was set to private,
                 // then allow to re-upload it.
-                if ($result->type == $t->type && $result->public) {
+                if ($result->public) {
                     return json(trans('skinlib.upload.repeated'), 0, ['tid' => $result->tid]);
                 }
             }
@@ -389,14 +389,6 @@ class SkinlibController extends Controller
 
         if ($t->uploader != $user->uid && !$user->isAdmin()) {
             return json(trans('skinlib.no-permission'), 1);
-        }
-
-        $duplicate = Texture::where('hash', $t->hash)
-            ->where('type', $request->input('model'))
-            ->where('tid', '<>', $t->tid)
-            ->first();
-        if ($duplicate && $duplicate->public) {
-            return json(trans('skinlib.model.duplicate', ['name' => $duplicate->name]), 1);
         }
 
         $t->type = $request->input('model');

--- a/resources/lang/en/skinlib.yml
+++ b/resources/lang/en/skinlib.yml
@@ -88,7 +88,6 @@ rename:
 
 model:
   success: The texture's model was changed to :model successfully.
-  duplicate: "The same texture available for the chosen model already exists in skinlib (Name: :name). You can add it to your closet directly."
 
 no-permission: You have no permission to moderate this texture.
 non-existent: No such texture.

--- a/tests/HttpTest/ControllersTest/SkinlibControllerTest.php
+++ b/tests/HttpTest/ControllersTest/SkinlibControllerTest.php
@@ -947,17 +947,6 @@ class SkinlibControllerTest extends TestCase
             'hash' => $texture->hash,
         ]);
 
-        // Should fail if there is already a texture with same hash and chosen model
-        $this->actingAs($uploader)
-            ->postJson('/skinlib/model', [
-                'tid' => $texture->tid,
-                'model' => 'alex',
-            ])
-            ->assertJson([
-                'code' => 1,
-                'message' => trans('skinlib.model.duplicate', ['name' => $duplicate->name]),
-            ]);
-
         // Allow private texture
         $duplicate->public = false;
         $duplicate->save();


### PR DESCRIPTION
现在 Blessing Skin 有个问题：在皮肤库中上传一份与皮肤库中已有的某一份材质相同的材质（Hash 相同），如果选择了不同的模型，那么 BS 仍然会将其判定为两份不同的材质。这个问题在 LittleSkin 上稳定复现。

既然 Hash 相同，那么这两份材质其实应该是同一份。但是一份材质只可能会有一种模型（default / slim / cape），如果两份材质的模型不同，那么它们的 Hash 也不相同才对。

这个 PR 修改了对重复材质的判定规则，将材质模型从判定条件中去除，以解决这个问题。

_另请参阅：#132_