### PR TITLE
Fix a bug of redirecting https to http

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -14,6 +14,12 @@
     RewriteRule (^\.|/\.) - [F]
     RewriteRule ^storage/.* - [F]
 
+    # Redirect trailing slashes if not a folder (behind a reverse proxy)
+    RewriteCond %{HTTP:X-Forwarded-Proto} ^https$
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_URI} (.+)/$
+    RewriteRule ^ "%{HTTP:X-Forwarded-Proto}://%{HTTP_HOST}%1" [L,R=301]
+    
     # Redirect trailing slashes if not a folder
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_URI} (.+)/$


### PR DESCRIPTION
## The Scene 场景

user <-> hmcl <-https-> nginx (load balancer/cdn) <-http-> apache (in docker) <-> blessing-skin-server (yggdrasil-api)

客户端与 nginx 使用 https 相连，nginx 回源使用 http 。

## The Problem 问题描述

问题在于 .htaccess 中，laravel 用于去除结尾 / 的配置，并没有考虑回源使用 http 的情况，apache 会从 https 跳转到 http。结果上来看，为了去掉结尾的 / ，会多跳转一次。即，https /api/yggdrasil/ => http /api/yggdrasil => https /api/yggdrasil

浏览器上感觉不到什么问题（由于 mitm 风险，浏览器其实应该警告一下的）。

hmcl 可能为了代码编写方便，为端点末尾自动加上了一个 / ，即 /api/yggdrasil/ 。为了去掉结尾的 / ，自动跳转到 http /api/yggdrasil 时，由于降级到不安全的协议，Java 会抛出错误 malformed response ，启动失败。

## Environment 运行环境

- Blessing Skin 版本 (Version of Blessing Skin): 5.0.0
- PHP 版本 (Version of PHP): 7.4.8
- Apache / Nginx: Apache/2.4.38 (Debian)
- 什么浏览器，出现错误时的地址栏 URL 是什么 (Which browser and URL): https://xxxx/api/yggdrasil/

## 关于这个 pull request

该 pull request 主要修改了一下 .htaccess ，在每次进行去除结尾 / 跳转前，先检测一下 X-Forwarded-Proto 是否为 https ，如果是，则直接跳转到 https 开头结尾没有 / 的 url 上去，解决问题同时，降低 rtt，提升一点点点用户体验。

虽然这个问题是因为插件引起的，但是修复需要在主项目上进行，故将这个 pull request 发到了这里。

这个修补其实并不是很“优雅”，但是能力所限，我能做到的最好方式就是这样。如果 apache 存在短路求值的话，可能对程序的影响不会非常大。

作为上游的 laravel 好像也存在这个问题，但是那里人多，怕被锤（qwq），所以先发到这里，有人 apache 语法使用的比较熟练的，可以修改一下，然后帮忙向上游提交一下这个问题。

该补丁在线上服务器测试通过（即上文所提到的那个场景），对于一般情况下，直接使用 http 访问的情况，也进行了测试，没有影响。

不使用该补丁的一种方式是在 load balancer/cdn 到源站间也使用 https ，即打开 Cloudflare 的全程（Full）加密。