### PR TITLE
修复启动器登录时500错误

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -38,10 +38,19 @@ class AuthServiceProvider extends ServiceProvider
             'ReportsManagement.Read' => 'auth.oauth.scope.reports-management.read',
             'ReportsManagement.ReadWrite' => 'auth.oauth.scope.reports-management.readwrite',
         ];
-
+        // 添加 Yggdrasil Connect 插件的作用域
+        $yggdrasilScopes = [
+            'openid' => 'LittleSkin\\YggdrasilConnect::scopes.openid',
+            'profile' => 'LittleSkin\\YggdrasilConnect::scopes.profile',
+            'email' => 'LittleSkin\\YggdrasilConnect::scopes.email',
+            'offline_access' => 'LittleSkin\\YggdrasilConnect::scopes.offline-access',
+            'Yggdrasil.PlayerProfiles.Read' => 'LittleSkin\\YggdrasilConnect::scopes.player-profiles.read',
+            'Yggdrasil.PlayerProfiles.Select' => 'LittleSkin\\YggdrasilConnect::scopes.player-profiles.select',
+            'Yggdrasil.Server.Join' => 'LittleSkin\\YggdrasilConnect::scopes.server.join',
+        ];
         $scopes = Cache::get('scopes', []);
 
-        Passport::tokensCan(array_merge($defaultScopes, $scopes));
+        Passport::tokensCan(array_merge($defaultScopes, $yggdrasilScopes, $scopes));
 
         Passport::setDefaultScope(['User.Read']);
     }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "immer": "^7.0.4",
     "jquery": "^3.6.0",
     "lodash.debounce": "^4.0.8",
+    "lcobucci/jwt": "^4.0",
     "nanoid": "^3.1.9",
     "prompts": "^2.4.0",
     "react": "^17.0.1",


### PR DESCRIPTION
1，在用 Laravel Passport + League OAuth2 Server + yggdrasil-connect 插件时，请求的 scope（如 Yggdrasil.PlayerProfiles.Select、Yggdrasil.Server.Join）没有被 Laravel Passport 正确注册。
2，插件的 callbacks.php 虽然会往数据库 scopes 表插入这些 scope，但 Laravel Passport 只会读取 AuthServiceProvider 里注册的 scope。
3，项目缺少 lcobucci/jwt 这个 PHP 包