### PR TITLE
修复邮箱验证链接安全问题

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -350,14 +350,14 @@ class AuthController extends Controller
             throw new PrettyPageException(trans('user.verification.disabled'), 1);
         }
 
-        abort_unless($request->hasValidSignature(false) && hash_equals((string)$request->route('hash'), sha1($user->email)), 403, trans('auth.verify.invalid'));
+        abort_unless($request->hasValidSignature(false) && hash_equals((string)$request->route('hash'), hash('sha256', $user->email)), 403, trans('auth.verify.invalid'));
 
         return view('auth.verify');
     }
 
     public function handleVerify(Request $request, User $user)
     {
-        abort_unless($request->hasValidSignature(false) && hash_equals((string)$request->route('hash'), sha1($user->email)), 403, trans('auth.verify.invalid'));
+        abort_unless($request->hasValidSignature(false) && hash_equals((string)$request->route('hash'), hash('sha256', $user->email)), 403, trans('auth.verify.invalid'));
 
         ['email' => $email] = $request->validate(['email' => 'required|email']);
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -344,20 +344,20 @@ class AuthController extends Controller
         return redirect('/user');
     }
 
-    public function verify(Request $request)
+    public function verify(Request $request, User $user)
     {
         if (!option('require_verification')) {
             throw new PrettyPageException(trans('user.verification.disabled'), 1);
         }
 
-        abort_unless($request->hasValidSignature(false), 403, trans('auth.verify.invalid'));
+        abort_unless($request->hasValidSignature(false) && hash_equals((string)$request->route('hash'), sha1($user->email)), 403, trans('auth.verify.invalid'));
 
         return view('auth.verify');
     }
 
     public function handleVerify(Request $request, User $user)
     {
-        abort_unless($request->hasValidSignature(false), 403, trans('auth.verify.invalid'));
+        abort_unless($request->hasValidSignature(false) && hash_equals((string)$request->route('hash'), sha1($user->email)), 403, trans('auth.verify.invalid'));
 
         ['email' => $email] = $request->validate(['email' => 'required|email']);
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -157,7 +157,7 @@ class UserController extends Controller
             return json(trans('user.verification.verified'), 1);
         }
 
-        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => sha1($user->email)], false);
+        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => hash('sha256', $user->email)], false);
 
         try {
             Mail::to($user->email)->send(new EmailVerification(url($url)));

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -157,7 +157,7 @@ class UserController extends Controller
             return json(trans('user.verification.verified'), 1);
         }
 
-        $url = URL::signedRoute('auth.verify', ['user' => $user], null, false);
+        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => sha1($user->email)], false);
 
         try {
             Mail::to($user->email)->send(new EmailVerification(url($url)));

--- a/app/Listeners/SendEmailVerification.php
+++ b/app/Listeners/SendEmailVerification.php
@@ -4,6 +4,7 @@ namespace App\Listeners;
 
 use App\Mail\EmailVerification;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\URL;
 

--- a/app/Listeners/SendEmailVerification.php
+++ b/app/Listeners/SendEmailVerification.php
@@ -13,7 +13,7 @@ class SendEmailVerification
     public function handle(User $user)
     {
         if (option('require_verification')) {
-            $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => sha1($user->email)], false);
+            $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => hash('sha256', $user->email)], false);
 
             try {
                 Mail::to($user->email)->send(new EmailVerification(url($url)));

--- a/app/Listeners/SendEmailVerification.php
+++ b/app/Listeners/SendEmailVerification.php
@@ -12,7 +12,7 @@ class SendEmailVerification
     public function handle(User $user)
     {
         if (option('require_verification')) {
-            $url = URL::signedRoute('auth.verify', ['user' => $user->uid], null, false);
+            $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => sha1($user->email)], false);
 
             try {
                 Mail::to($user->email)->send(new EmailVerification(url($url)));

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,8 +41,8 @@ Route::prefix('auth')->name('auth.')->group(function () {
             Route::post('bind', 'AuthController@fillEmail')->name('verify');
         });
 
-    Route::get('verify/{user}', 'AuthController@verify')->name('verify');
-    Route::post('verify/{user}', 'AuthController@handleVerify')->name('handle.verify');
+    Route::get('verify/{user}/{hash}', 'AuthController@verify')->name('verify');
+    Route::post('verify/{user}/{hash}', 'AuthController@handleVerify')->name('handle.verify');
 });
 
 Route::prefix('user')

--- a/tests/HttpTest/ControllersTest/AuthControllerTest.php
+++ b/tests/HttpTest/ControllersTest/AuthControllerTest.php
@@ -724,7 +724,7 @@ class AuthControllerTest extends TestCase
 
     public function testVerify()
     {
-        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => 1, 'hash' => sha1('a@b.c')], false);
+        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => 1, 'hash' => hash('sha256', 'a@b.c')], false);
 
         // should be forbidden if account verification is disabled
         option(['require_verification' => false]);
@@ -732,17 +732,17 @@ class AuthControllerTest extends TestCase
         option(['require_verification' => true]);
 
         // invalid link
-        $this->get(route('auth.verify', ['user' => 1, 'hash' => sha1('a@b.c')]))->assertForbidden();
+        $this->get(route('auth.verify', ['user' => 1, 'hash' => hash('sha256', 'a@b.c')]))->assertForbidden();
 
         $user = User::factory()->create(['verified' => false]);
-        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => sha1($user->email)], false);
+        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => hash('sha256', $user->email)], false);
         $this->get($url)->assertViewIs('auth.verify');
     }
 
     public function testHandleVerify()
     {
         $user = User::factory()->create(['verified' => false]);
-        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => sha1($user->email)], false);
+        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => hash('sha256', $user->email)], false);
 
         // empty email
         $this->post($url, [], ['Referer' => $url])->assertRedirect($url);

--- a/tests/HttpTest/ControllersTest/AuthControllerTest.php
+++ b/tests/HttpTest/ControllersTest/AuthControllerTest.php
@@ -724,7 +724,7 @@ class AuthControllerTest extends TestCase
 
     public function testVerify()
     {
-        $url = URL::signedRoute('auth.verify', ['user' => 1], null, false);
+        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => 1, 'hash' => sha1('a@b.c')], false);
 
         // should be forbidden if account verification is disabled
         option(['require_verification' => false]);
@@ -732,17 +732,17 @@ class AuthControllerTest extends TestCase
         option(['require_verification' => true]);
 
         // invalid link
-        $this->get(route('auth.verify', ['user' => 1]))->assertForbidden();
+        $this->get(route('auth.verify', ['user' => 1, 'hash' => sha1('a@b.c')]))->assertForbidden();
 
         $user = User::factory()->create(['verified' => false]);
-        $url = URL::signedRoute('auth.verify', ['user' => $user], null, false);
+        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => sha1($user->email)], false);
         $this->get($url)->assertViewIs('auth.verify');
     }
 
     public function testHandleVerify()
     {
         $user = User::factory()->create(['verified' => false]);
-        $url = URL::signedRoute('auth.verify', ['user' => $user], null, false);
+        $url = URL::temporarySignedRoute('auth.verify', Carbon::now()->addHour(), ['user' => $user, 'hash' => sha1($user->email)], false);
 
         // empty email
         $this->post($url, [], ['Referer' => $url])->assertRedirect($url);


### PR DESCRIPTION
@shhzhang 发现当前邮箱验证链接存在以下安全问题：

1. 验证链接永不过期
2. 验证链接仅对用户ID进行了签名

其中问题2比较严重，如果用户在收到验证链接后故意不完成验证，又把邮箱改成其他任意邮箱，之前收到的验证链接仍然能继续使用，从而可以绑定任意邮箱。

#675 的修复似乎仅在签名中增加了时间戳，只解决了问题1，且修复方式较为复杂，本 PR 使用 `temporarySignedRoute` 进行修复。